### PR TITLE
Added Django 1.8 compatibility.

### DIFF
--- a/templatetag_handlebars/templatetags/templatetag_handlebars.py
+++ b/templatetag_handlebars/templatetags/templatetag_handlebars.py
@@ -34,14 +34,14 @@ def verbatim_tags(parser, token, endtagname):
         if token.contents == endtagname:
             break
 
-        if token.token_type == template.TOKEN_VAR:
+        if token.token_type == template.base.TOKEN_VAR:
             text_and_nodes.append('{{')
             text_and_nodes.append(token.contents)
 
-        elif token.token_type == template.TOKEN_TEXT:
+        elif token.token_type == template.base.TOKEN_TEXT:
             text_and_nodes.append(token.contents)
 
-        elif token.token_type == template.TOKEN_BLOCK:
+        elif token.token_type == template.base.TOKEN_BLOCK:
             try:
                 command = token.contents.split()[0]
             except IndexError:
@@ -58,7 +58,7 @@ def verbatim_tags(parser, token, endtagname):
                     raise
             text_and_nodes.append(node)
 
-        if token.token_type == template.TOKEN_VAR:
+        if token.token_type == template.base.TOKEN_VAR:
             text_and_nodes.append('}}')
 
     return text_and_nodes


### PR DESCRIPTION
As of Django 1.8 the TOKEN_* globals are no longer imported in
django.template.__init__.py.